### PR TITLE
Fix optional survey questions

### DIFF
--- a/lib/src/ui/question_step.dart
+++ b/lib/src/ui/question_step.dart
@@ -59,7 +59,6 @@ class RPUIQuestionStepState extends State<RPUIQuestionStep> with CanSaveResult {
           t.cancel();
           skipQuestion();
         }
-        blocQuestion.sendReadyToProceed(true);
       });
     }
 


### PR DESCRIPTION
These changes allow having required survey questions unless the `optional` flag is used. 

The 'next' button is not displayed until the study participant answers the question.  