### PR TITLE
Mario-bermonti/issue136

### DIFF
--- a/lib/src/ui/task.dart
+++ b/lib/src/ui/task.dart
@@ -179,6 +179,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
           _translateTaskResult(RPLocalizations.of(context)!, _taskResult!);
     }
     translatedTaskResult?.startDate = _taskResult?.startDate;
+    translatedTaskResult?.endDate = _taskResult?.endDate;
     widget.onSubmit?.call(translatedTaskResult ?? _taskResult!);
   }
 

--- a/lib/src/ui/task.dart
+++ b/lib/src/ui/task.dart
@@ -178,6 +178,7 @@ class RPUITaskState extends State<RPUITask> with CanSaveResult {
       translatedTaskResult =
           _translateTaskResult(RPLocalizations.of(context)!, _taskResult!);
     }
+    translatedTaskResult?.startDate = _taskResult?.startDate;
     widget.onSubmit?.call(translatedTaskResult ?? _taskResult!);
   }
 


### PR DESCRIPTION
These changes include 2 important fixes:

- Fix `RPTaskResult` 's `startTime` for tasks: Now startTime is correctly set when the answers to `RPTaskResult` are translated into the language of the locale used during the app. Originally, the `startTime` was being set to the time the translated `RPTaskResult` was created.
- Fix `RPTaskResult`'s `endTime` for tasks: Now endTime is correctly set when the answers to `RPTaskResult` are translated into the language of the locale used during the app. Originally, the `endTime` was not being set in the translated `RPTaskResult` so it became null.

Closes issue # 136